### PR TITLE
Small tweak to ~/Applications patch

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,8 +57,8 @@ namespace :install do
 
     if File.exists?('/Applications/Google Chrome.app')
       sh "open '/Applications/Google Chrome.app'"
-    elsif File.exists?(File.expand_path('~/Applications/Google Chrome.app'))
-      sh "open '~/Applications/Google Chrome.app'"
+    elsif File.exists?(path = File.expand_path('~/Applications/Google Chrome.app'))
+      sh "open '#{path}'"
     end
 
     sh "open builds/dotjs.crx &"


### PR DESCRIPTION
Using the hardcoded relative path will create a path like '/Users/me/Desktop/dotjs/~/Applications/Google\ Chrome.app' to be created when you try to open the app.  This fails obviously. I just replaced the relative path with the absolute one, already found above with expand_path.
