### PR TITLE
Suppress logging and specify a bind address.

### DIFF
--- a/bin/djsd
+++ b/bin/djsd
@@ -1,14 +1,33 @@
 #!/usr/bin/env ruby
 
-if (%w( -h --help -help help ) & ARGV).length > 0
-  puts "usage: djsd [-hv]"
-  puts "starts dotjs server in the foreground. kill with ^C"
-  exit
-end
+require "optparse"
 
-if ARGV.include?('-v')
-  puts "djsd 1.3"
-  exit
+options = { :Port => 3131 }
+
+opts = OptionParser.new("", 24, '  ') do |opts|
+  opts.banner = "Usage: djsd [options]"
+
+  opts.on("-o", "--host Host", "listen on HOST (default: 0.0.0.0)") do |host|
+    options[:BindAddress] = host
+  end
+
+  opts.on("-q", "--quiet", "suppress access log output") do
+    require 'webrick'
+    options[:AccessLog] = [[ WEBrick::Log.new('/dev/null'), 
+                             WEBrick::AccessLog::COMBINED_LOG_FORMAT ]]
+  end
+
+  opts.on_tail("-h", "--help", "show this message") do
+    puts opts
+    exit
+  end
+
+  opts.on_tail("-v", "--version", "show version") do
+    puts "djsd 1.3"
+    exit
+  end
+
+  opts.parse! ARGV
 end
 
 require 'webrick'
@@ -29,7 +48,7 @@ dotjs = Class.new(WEBrick::HTTPServlet::AbstractServlet) do
   end
 end
 
-server = WEBrick::HTTPServer.new(:Port => 3131)
+server = WEBrick::HTTPServer.new(options)
 server.mount('/', dotjs)
 
 %w( INT TERM ).each do |sig|


### PR DESCRIPTION
I switched to optparse, and added options to shut up WEBrick logging as well as bind to a specific address.  Didn't update version, you can bump if you see fit.
