### PR TITLE
so that hitting the server directly does not asplode

### DIFF
--- a/bin/djsd
+++ b/bin/djsd
@@ -18,9 +18,9 @@ dotjs = Class.new(WEBrick::HTTPServlet::AbstractServlet) do
     file    = File.expand_path("#{request.path.gsub('/','')}")
     default = File.expand_path("default.js")
 
-    body = ''
-    body << File.read(default) + "\n" if File.exists?(default)
-    body << File.read(file) if File.exists?(file)
+    body = "// dotjs is working! //\n"
+    body << File.read(default) + "\n" if File.file?(default)
+    body << File.read(file) if File.file?(file)
 
     response.status = body.empty? ? 204 : 200
     response['Access-Control-Allow-Origin'] = '*'


### PR DESCRIPTION
this should fix the misunderstanding on issue #32 to some degree.  it simply makes sure that the .js files we're trying to source are actually files, not just exists? which will try to read a directory on a root hit, leading people to believe that things are broke.  Also, so there is some output, I'm prepending a javascript comment at the beginning.
