### PR TITLE
Making dotjs usable on multi-frame documents.

### DIFF
--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -5,6 +5,7 @@
   "icons": { "48": "icon48.png",
             "128": "icon128.png" },
   "content_scripts": [{
+    "all_frames": true,
     "run_at":     "document_start",
     "matches":    ["http://*/*", "https://*/*"],
     "js":         ["jquery.js", "dotjs.js"]


### PR DESCRIPTION
Hi,

I have been trying to use dotjs to script Gmail. I realized that Gmail uses iframes and dotjs runs only once, for the master document.

This patch sets a flag (all_frames) mentioned on the [content scripts page](http://code.google.com/chrome/extensions/content_scripts.html), so that content scripts run on every frame.

This allows scipting of Gmail content, which is very cool! :)

Cheers,
Arvind
