### PR TITLE
Make use of first-level paths

### DIFF
--- a/ext/dotjs.js
+++ b/ext/dotjs.js
@@ -1,10 +1,17 @@
-$.ajax({
-  url: 'http://localhost:3131/'+window.location.host.replace('www.','')+'.js',
-  dataType: 'text',
-  success: function(d){
-    $(function(){ eval(d) })
-  },
-  error: function(){
-    console.log('no dotjs server found at localhost:3131')
-  }
-})
+function dotjs(u) {
+  $.ajax({
+    url: u,
+    dataType: 'text',
+    success: function(d){
+      $(function(){ eval(d) })
+    },
+    error: function(){
+      console.log('no dotjs server found at localhost:3131')
+    }
+  });
+}
+subdomain = window.location.pathname.split('/')[1]
+if (subdomain) {
+  dotjs('http://localhost:3131/'+window.location.host.replace('www.','')+'.'+subdomain+'.js');
+}
+dotjs('http://localhost:3131/'+window.location.host.replace('www.','')+'.js');

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "dotjs",
+  "name": "dotjs-tempfork",
   "version": "1.3",
   "description": "~/.js",
   "icons": { "48": "icon48.png",


### PR DESCRIPTION
(So I don't know if this is the right way to implement it but it could at least start a discussion I guess :) )

So basically there are a few cases where it'd be useful if I could load different js files based on the first-level path.

For example (and yes, google is the only example I can think of right now) Google Reader's URL is www.google.com/reader/..., Google Calendar is www.google.com/calendar/..., and so on. I could create separate js files like google.com.reader.js for reader, google.com.calendar.js for gcal, and it could still load the global google.com.js if i want to modify something on all my google pages.

I do realize it is probably mostly cosmetic and my customizations for calendar and reader probably wouldn't mess with each other if I'd just put everything into google.com.js (and if they do mix up something I could do the detection in the google.com.js file itself), but I guess it's nice to keep them separate.
