### PR TITLE
protect against CORS-enabled stealing of scripts in ~/.js 

### DIFF
--- a/bin/djsd
+++ b/bin/djsd
@@ -23,8 +23,10 @@ dotjs = Class.new(WEBrick::HTTPServlet::AbstractServlet) do
     body << File.read(file) if File.file?(file)
 
     response.status = body.empty? ? 204 : 200
-    if request.header['origin'].length == 1 and request.header['origin'][0].match(request.path.gsub('/','').gsub(/\.js$/,'') + '$')
-      response['Access-Control-Allow-Origin'] = request.header['origin'][0]
+    if request.header['origin'].length == 1 and
+      request.path.length != 1 and
+      request.header['origin'][0].match(request.path.gsub('/','').gsub(/\.js$/,'') + '$')
+        response['Access-Control-Allow-Origin'] = request.header['origin'][0]
     end
     response['Content-Type'] = 'text/javascript'
     response.body = body


### PR DESCRIPTION
Implementing the fix [proposed](https://github.com/defunkt/dotjs/issues/26#issuecomment-1293228) by westonruter this patch prevents CORS on ~/.js by allowing access only to origins matching the request URI path.

This works in current stable (12.0.742.122) and beta (13.0.782.55) versions of Chrome, the latter one should not actually be affected by the patch since it is apparently not relying on the Access-Control-Allow-Origin/Origin mechanism for XHRs by extensions any more.
