### PR TITLE
Broken install on newly created accounts

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,8 +42,9 @@ namespace :install do
   desc "Install launch agent"
   task :agent do
     plist = "com.github.dotjs.plist"
-    agent = File.expand_path("~/Library/LaunchAgents/#{plist}")
-
+    agent_dir = File.expand_path("~/Library/LaunchAgents/")
+    agent = File.join(agent_dir, plist)
+    Dir.mkdir(agent_dir) unless File.exists?(agent_dir)
     File.open(agent, "w") do |f|
       f.puts ERB.new(IO.read(plist)).result(binding)
     end


### PR DESCRIPTION
Hi, 

In Lion, the ~/Library/LaunchAgents directory does not exists by default. This patch create it if it does not exists.

regards.
