### PR TITLE
Prevent WEBrick from leaking visited sites to syslog

### DIFF
--- a/bin/djsd
+++ b/bin/djsd
@@ -41,7 +41,7 @@ dotjs = Class.new(WEBrick::HTTPServlet::AbstractServlet) do
   end
 end
 
-server = WEBrick::HTTPServer.new(:Port => 3131)
+server = WEBrick::HTTPServer.new(:Port => 3131, :AccessLog => [])
 server.mount('/', dotjs)
 
 %w( INT TERM ).each do |sig|


### PR DESCRIPTION
... as complained about in defunkt/dotjs#66
