### PR TITLE
Bump manifest version to 2

### DIFF
--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -1,5 +1,6 @@
 {
   "name": "dotjs",
+  "manifest_version": 2,
   "version": "1.6",
   "description": "~/.js",
   "icons": { "48": "icon48.png",


### PR DESCRIPTION
Q3 2013 Chrome will stop supporting manifest version 1. There is no
rush, but it's better to change it now than never. ;)

http://developer.chrome.com/extensions/manifestVersion.html#manifest-v1-2012q3

I haven't built a new version of the extension though.
