### PR TITLE
Update Example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -30,7 +30,7 @@ modifications. With dotjs, just add or edit files in
 
     $ cat ~/.js/github.com.js
     // swap github logo with trollface
-    $('a.header-logo-blacktocat').html(
+    $('a[class^=header-logo-]').html(
         $('<img>')
             .attr('src', '//bit.ly/ghD24e')
             .css({'width': 'auto', 'height': '22px'})


### PR DESCRIPTION
Class of the github logo is `header-logo-invertocat` now.
I think it is better to replace class beginning with `header-logo-`.
