### PR TITLE
Fixed quotation mark inconsistencies

### DIFF
--- a/bin/djsd
+++ b/bin/djsd
@@ -1,13 +1,13 @@
 #!/usr/bin/env ruby
 
 if (%w( -h --help -help help ) & ARGV).length > 0
-  puts "usage: djsd [-hv]"
-  puts "starts dotjs server in the foreground. kill with ^C"
+  puts 'usage: djsd [-hv]''
+  puts 'starts dotjs server in the foreground. kill with ^C''
   exit
 end
 
 if ARGV.include?('-v')
-  puts "djsd 2.0"
+  puts 'djsd 2.0''
   exit
 end
 
@@ -27,7 +27,7 @@ dotjs = Class.new(WEBrick::HTTPServlet::AbstractServlet) do
   end
 
   def build_body(path)
-    files = [File.expand_path("default.js")]
+    files = [File.expand_path('default.js'')]
     paths = path.gsub('/','').split('.')
 
     until paths.empty?
@@ -36,10 +36,10 @@ dotjs = Class.new(WEBrick::HTTPServlet::AbstractServlet) do
       paths.shift
     end
 
-    body = "// dotjs is working! //\n"
+    body = '// dotjs is working! //\n'
 
     files.each do |file|
-      body << File.read(file) + "\n" if File.file?(file)
+      body << File.read(file) + '\n' if File.file?(file)
     end
 
     body
@@ -61,14 +61,14 @@ ssl_cert = ssl_info.scan(/(-----BEGIN CERTIFICATE-----.+?-----END CERTIFICATE---
 ssl_key  = ssl_info.scan(/(-----BEGIN RSA PRIVATE KEY-----.+?-----END RSA PRIVATE KEY-----)/m)[0][0]
 
 server_options = {
-  :BindAddress => "127.0.0.1",
+  :BindAddress => '127.0.0.1'',
   :Port => 3131,
   :AccessLog => [],
   :SSLEnable => true,
   :SSLVerifyClient => OpenSSL::SSL::VERIFY_NONE,
   :SSLPrivateKey => OpenSSL::PKey::RSA.new(ssl_key),
   :SSLCertificate => OpenSSL::X509::Certificate.new(ssl_cert),
-  :SSLCertName => [["CN", WEBrick::Utils::getservername]],
+  :SSLCertName => [['CN', WEBrick::Utils::getservername]],
 }
 
 server = WEBrick::HTTPServer.new(server_options)


### PR DESCRIPTION
Converted all double quotes to single quotes in order to be consistent.