### PR TITLE
Changed bind address to localhost to allow IPv6 connections

### DIFF
--- a/bin/djsd
+++ b/bin/djsd
@@ -61,7 +61,7 @@ ssl_cert = ssl_info.scan(/(-----BEGIN CERTIFICATE-----.+?-----END CERTIFICATE---
 ssl_key  = ssl_info.scan(/(-----BEGIN RSA PRIVATE KEY-----.+?-----END RSA PRIVATE KEY-----)/m)[0][0]
 
 server_options = {
-  :BindAddress => "127.0.0.1",
+  :BindAddress => "localhost",
   :Port => 3131,
   :AccessLog => [],
   :SSLEnable => true,


### PR DESCRIPTION
I like to keep my connections v6 only and I don't see any downside in this so I changed the bind address of the web server from 127.0.0.1 to localhost.
